### PR TITLE
fix: PY_SSIZE_T_CLEAN macro should be #format

### DIFF
--- a/pyaudio/src/_portaudiomodule.c
+++ b/pyaudio/src/_portaudiomodule.c
@@ -23,7 +23,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include <stdio.h>
 #include "Python.h"
 #include "portaudio.h"


### PR DESCRIPTION
We should build wheel and run setup.py again.